### PR TITLE
Fix summary generation bug

### DIFF
--- a/summarizer/utils.py
+++ b/summarizer/utils.py
@@ -86,8 +86,8 @@ def generate_summary(content, media_type="text"):
                 frequency_penalty=0.0,
                 presence_penalty=0.0
             )
-            if not detailed_summary or 'error' in detailed_summary:
-                logger.error(f"OpenAI error response: {detailed_summary}")
+            if not detailed_response or 'error' in detailed_response:
+                logger.error(f"OpenAI error response: {detailed_response}")
 
             detailed_summary = detailed_response.choices[0].message.content.strip()
 

--- a/summarizer/views.py
+++ b/summarizer/views.py
@@ -88,7 +88,7 @@ def whatsapp_webhook(request):
         else:
             client.messages.create(from_='whatsapp:+14155238886', body="Processing text...", to=sender_number)
             try:
-                response_body = generate_summary(response_body)
+                response_body = generate_summary(message)
             except Exception as e:
                 response_body = handle_error(e)
 


### PR DESCRIPTION
## Summary
- fix reference to `detailed_response` when checking for errors in utils
- ensure text messages are summarized by passing `message` to the summary generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c7227ddc8323aee075d454cfc160